### PR TITLE
Removing reference to R from provision.yml

### DIFF
--- a/VagrantBuild/provision.yml
+++ b/VagrantBuild/provision.yml
@@ -13,11 +13,6 @@
       community.general.bundler:
         state: present
         gemfile: /vagrant/Gemfile
-        
-    - name: Add specified repository into sources list
-      ansible.builtin.apt_repository:
-        repo: deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/
-        state: present
 
     - name: Install build tools via apt
       ansible.builtin.apt:


### PR DESCRIPTION
Before Pip left he mercifully removed the dependence on R and R-markdown in the lessons, and removed most of the references to R in this repository. But it looks like something was missed in `provision.yml`. Considering we don't use R anymore to build the lessons and that it was causing issues when trying to provision a new VM, I have removed the step in `provision.yml` which adds the R repositories.